### PR TITLE
[WIP]ソーシャルログイン実装にあたって、DBを修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Things you may want to cover:
 |birthday|datatime|null: false|
 |phone_number|string|null: false|
 |self_introduction|string|
-|provider|stribg|index: true|
+|provider|string|index: true|
 |uid|string|index: true|
 
 ### Association

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Things you may want to cover:
 |birthday|datatime|null: false|
 |phone_number|string|null: false|
 |self_introduction|string|
+|provider|stribg|index: true|
+|uid|string|index: true|
 
 ### Association
 - has_one :delivery dependent::destroy
@@ -86,17 +88,6 @@ Things you may want to cover:
 |customer_id|integer|index: true, null: false|
 |card_id|integer|index: true, null: false|
 
-
-### Association
-- belongs_to :user
-
-## sns_credentialsテーブル
-
-|Column|Type|Options|
-|------|----|-------|
-|user_id|references|null: false, foreign_key: true|
-|provider|stribg|
-|uid|string|
 
 ### Association
 - belongs_to :user

--- a/db/migrate/20200114052218_add_column_users.rb
+++ b/db/migrate/20200114052218_add_column_users.rb
@@ -1,0 +1,6 @@
+class AddColumnUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :uid, :integer,index: true
+    add_column :users, :provider, :integer,index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_08_022715) do
+ActiveRecord::Schema.define(version: 2020_01_14_052218) do
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -20,6 +20,8 @@ ActiveRecord::Schema.define(version: 2020_01_08_022715) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "uid"
+    t.integer "provider"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
#WHAT
Usersテーブルへuid,providerカラムを追加するマイグレーションファイルを作成
ReadmeからSnsCredentialデータベースの記述を削除
ReadmeのUserデータベースにuid,providerカラムを追加

#WHY
ソーシャルログイン機能の実装をシンプルにするため
DB構造をシンプルにするため