### PR TITLE
ah_setting_ok

### DIFF
--- a/app/assets/stylesheets/items_show.scss
+++ b/app/assets/stylesheets/items_show.scss
@@ -21,12 +21,13 @@
         display: flex;
         justify-content: space-between;
         &--top-image{
-          height: 360px;
+          height: 430px;
           width: 300px;
           img {
           display:block;
           height: 300px;
           width: 300px;
+          margin-bottom: 4px;
           }          
           &--clear{
             line-height: 0;

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,6 @@
 class ItemsController < ApplicationController
   before_action :move_to_login, only: [:new, :create]
+  before_action :set_item, only: [:show]
 
   def index
   end
@@ -24,6 +25,10 @@ class ItemsController < ApplicationController
   end
   
   private
+
+  def set_item
+    @item = Item.find(params[:id])
+  end
 
   def move_to_login
     redirect_to new_user_session_path unless user_signed_in?

--- a/app/models/ah_condition.rb
+++ b/app/models/ah_condition.rb
@@ -1,0 +1,6 @@
+class AhCondition < ActiveHash::Base
+  self.data = [
+      {id: 1, name: '新品、未使用'}, {id: 2, name: '未使用に近い'}, {id: 3, name: '目立った傷や汚れなし'},
+      {id: 4, name: 'やや傷や汚れあり'}, {id: 5, name: '傷や汚れあり'}, {id: 6, name: '全体的に状態が悪い'}
+  ]
+end

--- a/app/models/ah_prefecture.rb
+++ b/app/models/ah_prefecture.rb
@@ -1,4 +1,4 @@
-class Prefecture < ActiveHash::Base
+class AhPrefecture < ActiveHash::Base
   self.data = [
       {id: 1, name: '北海道'}, {id: 2, name: '青森県'}, {id: 3, name: '岩手県'},
       {id: 4, name: '宮城県'}, {id: 5, name: '秋田県'}, {id: 6, name: '山形県'},

--- a/app/models/ah_shipping_charge.rb
+++ b/app/models/ah_shipping_charge.rb
@@ -1,0 +1,5 @@
+class AhShippingCharge < ActiveHash::Base
+  self.data = [
+      {id: 1, name: '送料込み(出品者負担)'}, {id: 2, name: '着払い(購入者負担)'}
+  ]
+end

--- a/app/models/ah_shipping_days.rb
+++ b/app/models/ah_shipping_days.rb
@@ -1,0 +1,5 @@
+class AhShippingDays < ActiveHash::Base
+  self.data = [
+      {id: 1, name: '1〜2日で発送'}, {id: 2, name: '2〜3日で発送'}, {id: 3, name: '4〜７日で発送'}
+  ]
+end

--- a/app/models/ah_shipping_method.rb
+++ b/app/models/ah_shipping_method.rb
@@ -1,0 +1,7 @@
+class AhShippingMethod < ActiveHash::Base
+  self.data = [
+      {id: 1, name: '未定'}, {id: 2, name: 'らくらくメルカリ便'}, {id: 3, name: 'ゆうメール'},
+      {id: 4, name: 'レターパック'}, {id: 5, name: '普通郵便(定形、定形外)'}, {id: 6, name: 'クロネコヤマト'},
+      {id: 7, name: 'ゆうパック'}, {id: 8, name: 'クリックポスト'}, {id: 9, name: 'ゆうパケット'}
+  ]
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -4,8 +4,14 @@ class Item < ApplicationRecord
   belongs_to :brand
   accepts_nested_attributes_for :brand
   belongs_to :category
-  extend ActiveHash::Associations::ActiveRecordExtensions
-  belongs_to_active_hash :prefecture
   belongs_to :user
+
+
+  extend ActiveHash::Associations::ActiveRecordExtensions
+  belongs_to_active_hash :ah_prefecture
+  belongs_to_active_hash :ah_condition
+  belongs_to_active_hash :ah_shipping_days
+  belongs_to_active_hash :ah_shipping_method
+  belongs_to_active_hash :ah_shipping_charge
 
 end

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -51,26 +51,6 @@
             %span 必須
           = f.collection_select :shipping_days, AhShippingDays.all, :id, :name
 
-          = f.fields_for :brand do |i|
-            = i.text_field :name
-          
-          = f.fields_for :item_images do |i|
-            = i.file_field :image
-          = f.fields_for :item_images do |i|
-            = i.file_field :image
-          = f.fields_for :item_images do |i|
-            = i.file_field :image
-          = f.fields_for :item_images do |i|
-            = i.file_field :image
-          = f.fields_for :item_images do |i|
-            = i.file_field :image
-          = f.fields_for :item_images do |i|
-            = i.file_field :image
-          = f.fields_for :item_images do |i|
-            = i.file_field :image
-          = f.fields_for :item_images do |i|
-            = i.file_field :image
-
       .item-show
         .item-show__left-head 販売価格(300〜9,999,999)
         .item-show__sell-price

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -30,26 +30,47 @@
           .item-show__categorie--input-bottom
             商品の状態
             %span 必須
-          = f.select :condition, [['新品、未使用', 1], ['未使用に近い', 2], ['目立った傷や汚れなし', 3], ['やや傷や汚れあり', 4], ['傷や汚れあり', 5], ['全体的に状態が悪い', 6]]
+          = f.collection_select :condition, AhCondition.all, :id, :name 
       .item-show
         .item-show__left-head 配送について
         .item-show__categorie
           .item-show__categorie--input-top
             配送料の負担
             %span 必須
-          = f.select :shipping_charge, [['送料込み(出品者負担)', 1], ['着払い(購入者負担)', 2]]
+          = f.collection_select :shipping_charge, AhShippingCharge.all, :id, :name
           .item-show__categorie--input-bottom
             配送の方法
             %span 必須
-          = f.select :shipping_method, [['未定', 1], ['らくらくメルカリ便', 2], ['ゆうメール', 3], ['レターパック', 4], ['普通郵便(定形、定形外)', 5], ['クロネコヤマト', 6], ['ゆうパック', 7], ['クリックポスト', 8], ['ゆうパケット', 9]]
+          = f.collection_select :shipping_method, AhShippingMethod.all, :id, :name
           .item-show__categorie--input-bottom
             配送元の地域
             %span 必須
-          = f.collection_select :ship_form, Prefecture.all, :id, :name
+          = f.collection_select :ship_form, AhPrefecture.all, :id, :name
           .item-show__categorie--input-bottom
             配送までの日数
             %span 必須
-          = f.select :shipping_days, [['1〜2日で発送', 1], ['2〜3日で発送', 2], ['4〜７日で発送', 3]]
+          = f.collection_select :shipping_days, AhShippingDays.all, :id, :name
+
+          = f.fields_for :brand do |i|
+            = i.text_field :name
+          
+          = f.fields_for :item_images do |i|
+            = i.file_field :image
+          = f.fields_for :item_images do |i|
+            = i.file_field :image
+          = f.fields_for :item_images do |i|
+            = i.file_field :image
+          = f.fields_for :item_images do |i|
+            = i.file_field :image
+          = f.fields_for :item_images do |i|
+            = i.file_field :image
+          = f.fields_for :item_images do |i|
+            = i.file_field :image
+          = f.fields_for :item_images do |i|
+            = i.file_field :image
+          = f.fields_for :item_images do |i|
+            = i.file_field :image
+
       .item-show
         .item-show__left-head 販売価格(300〜9,999,999)
         .item-show__sell-price

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -5,27 +5,35 @@
       .gray-container
         .white-container
           .item-name
-            スマホケース
+            = "#{@item.name}"
           .contents
             .contents__main-content
               .contents__main-content--top-image
-                %img{src: "https://image.itmedia.co.jp/mobile/articles/1903/01/st52693_sharpen-07.jpg"}
+                - image = @item.item_images.slice(0) 
+                = image_tag "#{image.image}" if image.present?
                 .contents__main-content--top-image--images
-                  %img{src: "https://image.itmedia.co.jp/mobile/articles/1903/01/st52693_sharpen-07.jpg"}
-                  %img{src: "https://image.itmedia.co.jp/mobile/articles/1903/01/st52693_sharpen-07.jpg"}
-                  %img{src: "https://image.itmedia.co.jp/mobile/articles/1903/01/st52693_sharpen-07.jpg"}
-                  %img{src: "https://image.itmedia.co.jp/mobile/articles/1903/01/st52693_sharpen-07.jpg"}
-                  %img{src: "https://image.itmedia.co.jp/mobile/articles/1903/01/st52693_sharpen-07.jpg"}
+                  - num = 0
+                  - while num < 5 do
+                    - image = @item.item_images.slice(num)
+                    = image_tag "#{image.image}" if image.present?
+                    - num = num + 1
+                .contents__main-content--top-image--images
+                  - num = 5
+                  - while num < 10 do
+                    - image = @item.item_images.slice(num)
+                    = image_tag "#{image.image}" if image.present?
+                    - num = num + 1
               %table.aaaaa{border: "1"}
                 %tr
                   %th 出品者
                   %td
-                    = link_to "苗字名前"
+                    = link_to "#{@item.user.nickname}"
                 %tr
                   %th カテゴリー
                   %td
                     = link_to do
-                      %div レディース
+                      %div
+                        = "#{@item.category.name}"
                     = link_to do
                       %i.fa.fa-chevron-right
                       %div 小物
@@ -35,7 +43,7 @@
                 %tr
                   %th ブランド
                   %td
-                    = link_to "カメハメハ"
+                    = link_to "#{@item.brand.name}"
                 %tr
                   %th 商品の状態
                   %td ボロボロ
@@ -48,7 +56,7 @@
                 %tr
                   %th 発送元地域
                   %td
-                    = link_to "熊本県"
+                    = link_to Prefecture.find(@item.ship_form).name
                 %tr
                   %th 発送日の目安
                   %td 2~3日で発送

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,6 @@ Rails.application.routes.draw do
     post 'address_users', to: 'users/registrations#create_address_user'
   end
   
-  resources :items, only: [:new, :create]
+  resources :items, only: [:new, :create, :show]
   resources :users, only: [:show, :new, :update]
 end


### PR DESCRIPTION
#WHAT
active hashに使用するモデルの作成
商品出品ページをactive hashを使った形に編集

#WHY
ビューの簡素化
active hashを使ったリスト表示を他のページで流用するため