### PR TITLE
user_sign_up_pach_1

### DIFF
--- a/app/views/devise/registrations/new_address_user.html.haml
+++ b/app/views/devise/registrations/new_address_user.html.haml
@@ -32,7 +32,7 @@
         .field
           = f.label :都道府県, class: "field__a"
           %br/
-          = f.text_field :prefecture_id, class: "address__textform"
+          = f.collection_select :prefecture_id, AhPrefecture.all, :id, :name, class: "address__textform"
         .field
           = f.label :郵便番号
           %br/


### PR DESCRIPTION
#WHAT
ユーザー登録ページで都道府県をリストで表示、登録
⬆️active hashの使用

#WHY
本家に近い形での登録ページを実装するため