### PR TITLE
item-register-update

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -63,8 +63,6 @@ class ItemsController < ApplicationController
 
   def update
     item = Item.find(params[:id])
-    item.update(item_params)
-    
     if item.update(item_params)
       redirect_to item_path(item.id)
     else

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -6,6 +6,7 @@ class ItemsController < ApplicationController
   end
 
   def show
+    @brand = Brand.find(@item.brand_id)
   end
 
   def buy_confirmation
@@ -57,6 +58,17 @@ class ItemsController < ApplicationController
     #データベースから、親カテゴリーのみ抽出し、配列化
     Category.where(ancestry: nil).each do |parent|
       @category_parent_array << parent.name
+    end
+  end
+
+  def update
+    item = Item.find(params[:id])
+    item.update(item_params)
+    
+    if item.save
+      redirect_to item_path(item.id)
+    else
+      render :edit
     end
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -65,7 +65,7 @@ class ItemsController < ApplicationController
     item = Item.find(params[:id])
     item.update(item_params)
     
-    if item.save
+    if item.update(item_params)
       redirect_to item_path(item.id)
     else
       render :edit

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -18,12 +18,7 @@
           .image-content__input-box
             .js-input#js-hidden-input0
               = f.fields_for :item_images do |i|
-                .js-file_group{data:{index: "#{i.index}"}}
-                  = i.label :image, class: :"item-image-box" do
-                    ドラッグアンドドロップ 
-                    %br/ 
-                    またはクリックしてファイルをアップロード
-                  = i.file_field :image, class: :"js-file"
+                = i.file_field :image, class: :"js-edit-file"
       .item-name
         .item-name__head
           商品名
@@ -96,5 +91,5 @@
           %p 禁止されている出品、行為を必ずご確認ください。
           %p またブランド品でシリアルナンバー等がある場合はご記載ください。偽ブランドの販売は犯罪であり処罰される可能性があります。
           %p また、出品をもちまして加盟店規約に同意したことになります。
-        = f.submit "出品する", class: "item-submit__submit"
-        = link_to "もどる", root_path
+        = f.submit "変更する", class: "item-submit__submit"
+        = link_to "キャンセル", item_path

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -43,25 +43,30 @@
                 %tr
                   %th ブランド
                   %td
-                    = link_to "#{@item.brand.name}"
+                    = link_to "#{@brand.name}"
                 %tr
                   %th 商品の状態
-                  %td ボロボロ
+                  %td 
+                    = link_to AhCondition.find(@item.condition).name
                 %tr
                   %th 配送料の負担
-                  %td 送料込み(出品者負担)
+                  %td 
+                    = link_to AhShippingCharge.find(@item.shipping_charge).name
                 %tr
                   %th 発送方法
-                  %td 未定
+                  %td 
+                    = link_to AhShippingMethod.find(@item.shipping_method).name
                 %tr
                   %th 発送元地域
                   %td
                     = link_to AhPrefecture.find(@item.ship_form).name
                 %tr
                   %th 発送日の目安
-                  %td 2~3日で発送
+                  %td
+                    = link_to AhShippingDays.find(@item.shipping_days).name
             .contents__plice-box
-              %span.contents__plice-box--plice ¥1,400
+              %span.contents__plice-box--plice 
+                = "¥" + @item.price.to_s(:delimited)
               %span.contents__plice-box--tax (税込)
               %span.contents__plice-box--fee 送料込み
               -if @item.id == current_user.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,7 @@ Rails.application.routes.draw do
   end
   
 
-  resources :items, only: [:new, :create, :show, :edit] do
+  resources :items, only: [:new, :create, :show, :edit, :update] do
     get 'buy_confirmation'
     collection do
       get 'get_category_children', defaults: { format: 'json' }


### PR DESCRIPTION
# What
アイテム詳細編集ページ作成
アイテムの詳細情報を詳細ページで表示させる
# Why
ユーザーが登録したアイテム情報を編集できるようにする

https://gyazo.com/24edfb41b74609742d1f01db17de6938