### PR TITLE
[WIP]商品検索機能LV1

### DIFF
--- a/app/assets/javascripts/asearch.js
+++ b/app/assets/javascripts/asearch.js
@@ -47,7 +47,7 @@ $(function() {
     // 孫カテゴリを追加する処理です　基本的に子要素と同じです！
     function buildGrandChildHTML(child){
       var html =`<a class="grand_child_category" id="${child.id}"
-                    href="category/${child.id}">${child.name}</a>`;
+                    href="/category/${child.id}">${child.name}</a>`;
       return html;
     }
   

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -33,6 +33,19 @@ class ItemsController < ApplicationController
 
   end
 
+  def search
+    @search_text = params[:keyword]
+    redirect_to root_path if params[:keyword] == "" 
+    split_keywords = params[:keyword].split(/[[:blank:]]+/)
+    @items = Item.all
+
+    split_keywords.each do |keyword|  # 分割したキーワードごとに検索
+      next if keyword == "" 
+      @items = @items.where( "name LIKE ? OR description LIKE ? ", "%#{keyword}%", "%#{keyword}%")
+    end
+
+  end
+
   # 以下全て、formatはjsonのみ
    # 親カテゴリーが選択された後に動くアクション
   def get_category_children

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -20,7 +20,7 @@ class Item < ApplicationRecord
             presence: true
   validates :name, length: { maximum: 40 }
   validates :description, length: { maximum: 1000 }
-  validates :price, :numericality => { :greater_than_or_equal_to => 300 } 
+  validates :price, :numericality => { :greater_than_or_equal_to => 300 }
 
 
   extend ActiveHash::Associations::ActiveRecordExtensions

--- a/app/views/items/_header.html.haml
+++ b/app/views/items/_header.html.haml
@@ -3,8 +3,8 @@
     .head__top
       = link_to root_path, class: "head__top__logo" do
         = image_tag 'fmarket_logo_red.svg', class: "head__top__logo__img"
-      %form.head__top__form
-        %input.head__top__form__search{name: "word-search", placeholder: "何かお探しですか？", type: "search"}/
+      %form.head__top__form{action: "/items/search", method: "GET"}
+        %input.head__top__form__search{name: "keyword", placeholder: "何かお探しですか？", type: "search"}/
         %button.head__top__form__btn
           %i.fab.fa-sistrix.fa-2x
     .head__bottom

--- a/app/views/items/search.html.haml
+++ b/app/views/items/search.html.haml
@@ -1,0 +1,52 @@
+%body
+  .body
+    #app
+      = render partial: 'items/header'
+      .items
+        .items__wrapper
+
+          .category
+            .category__items
+              - if @items.present?
+                .category__items__title
+                  %h3.category__items__title__type
+                    = @search_text + "の検索結果"
+                .category__items__contents
+                  .category__items__contents__tag
+                    %ul.products
+                      - @items.each do |item|
+                        %li.product
+                          .product__style
+                            = link_to item_path(item.id), class: "product__link" do
+                              .product__link__item
+                                .product__item__details
+                                  %span.product__item__details__price
+                                    = "¥" + item.price.to_s(:delimited)
+                                  = image_tag "#{item.item_images.slice(0).image}", class: "product__item__details__img"
+                                .product-wrapper
+                                  %span.product-name
+                                    = item.name
+              - else
+                .category__items__title
+                  %h3.category__items__title__type
+                    お探しの商品は存在しません
+
+      .camera
+      = render partial: 'users/exhibition'
+      %aside.aside
+        .bottom
+          .bottom__content
+            .bottom__content__left
+              .bottom__content__left__message
+                スマホでも難しいフリマアプリ
+              .bottom__content__left__text
+                今すぐ有料ダウンロード！
+              .bottom__logo
+                = image_tag 'logo_red.svg', class: "bottom__logo__merucari"
+                = link_to '' '#', class: "bottom__logo__apple" do
+                  = image_tag 'https://web-jp-assets.mercdn.net/_next/static/images/app-store-a5c17948c6fd6d5b60b13d421cd60b35.svg', class: "bottom__logo__apple__img"
+                = link_to '' 'https://play.google.com/store/apps/details?id=com.kouzoh.mercari&hl=ja', class: "bottom__logo__google" do
+                  = image_tag 'https://web-jp-assets.mercdn.net/_next/static/images/google-play-495575abb895b405aa6336b2a4304958.svg', class: "bottom__logo__google__img"
+            .bottom__content__right
+              = image_tag 'https://web-jp-assets.mercdn.net/_next/static/images/download_app_pc-a4418175e8be071827ac88d073f40e4a.png', class: "bottom__content__right__img"
+      = render partial: 'items/footer'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,7 @@ Rails.application.routes.draw do
     collection do
       get 'get_category_children', defaults: { format: 'json' }
       get 'get_category_grandchildren', defaults: { format: 'json' }
+      get 'search'
     end
 
     member do


### PR DESCRIPTION
#WHAT
ヘッダーの検索フォームから、商品の検索が出来る様に
商品名、もしくは商品紹介文に検索ワードが含まれた場合にレコードを取得
スペースで区切った場合は、AND検索で絞り込みをかけられる


#WHY
ユーザーが探している商品を効率的に絞り込むため

https://gyazo.com/6ef7888e7c518767fb48e49d482366ee

商品の画像が表示されていないのは、carryerwaveが原因で、すでに別ブランチで解決済みです